### PR TITLE
Revert unintentional change to test Windurst M2-3

### DIFF
--- a/scripts/zones/Heavens_Tower/npcs/Kupipi.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Kupipi.lua
@@ -91,7 +91,7 @@ function onTrigger(player, npc)
             player:startEvent(251)
         end
     elseif pNation == tpz.nation.WINDURST then
-        if currentMission == tpz.mission.id.windurst.THE_THREE_KINGDOMS and missionStatus == 1 then -- Fixed initial Windurst CS for mission
+        if currentMission == tpz.mission.id.windurst.THE_THREE_KINGDOMS and missionStatus == 0 then
             player:startEvent(95, 0, 0, 0, tpz.ki.LETTER_TO_THE_CONSULS_WINDURST)
         elseif currentMission == tpz.mission.id.windurst.THE_THREE_KINGDOMS and missionStatus == 11 then
             player:startEvent(101, 0, 0, tpz.ki.ADVENTURERS_CERTIFICATE)


### PR DESCRIPTION
<!-- place 'x' mark between square [] brackets to affirm: -->
**_I affirm:_**
- [x] that I agree to Project Topaz's [Limited Contributor License Agreement](http://project-topaz.com/blob/release/CONTRIBUTOR_AGREEMENT.md), as written on this date
- [x that I've _tested my code_ since the last commit in the PR, and will test after any later commits

Revert unintentional change to Kupipi for testing purposes.  